### PR TITLE
Adding template role for zwavejs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-ansible/elliotweiser.osx-command-line-tools
-ansible/geerlingguy*
+ansible/roles/elliotweiser.osx-command-line-tools
+ansible/roles/geerlingguy*

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+ansible/elliotweiser.osx-command-line-tools
+ansible/geerlingguy*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+lint:
+	markdownlint '**/*.md'
+
+fix-lint:
+	markdownlint '**/*.md'

--- a/ansible/roles/zwavejs/.travis.yml
+++ b/ansible/roles/zwavejs/.travis.yml
@@ -9,7 +9,7 @@ sudo: false
 addons:
   apt:
     packages:
-    - python-pip
+      - python-pip
 
 install:
   # Install ansible

--- a/ansible/roles/zwavejs/.travis.yml
+++ b/ansible/roles/zwavejs/.travis.yml
@@ -1,0 +1,29 @@
+---
+language: python
+python: "2.7"
+
+# Use the new container infrastructure
+sudo: false
+
+# Install ansible
+addons:
+  apt:
+    packages:
+    - python-pip
+
+install:
+  # Install ansible
+  - pip install ansible
+
+  # Check ansible version
+  - ansible --version
+
+  # Create ansible.cfg with correct roles_path
+  - printf '[defaults]\nroles_path=../' >ansible.cfg
+
+script:
+  # Basic role syntax check
+  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/ansible/roles/zwavejs/README.md
+++ b/ansible/roles/zwavejs/README.md
@@ -9,13 +9,21 @@ Docker
 
 ## Role Variables
 
-  ansible_nas_timezone
+    ansible_nas_timezone
 
 Timezone code for the container.
 
-  zwavejs_device
+    zwavejs_device
 
 Zwave serial device to attach to the Docker container
+
+
+    zwavejs_keys_s2_unauthenticated
+    zwavejs_keys_s2_authenticated
+    zwavejs_keys_s2_accesscontrol
+    zwavejs_keys_s0_legacy
+
+The various security keys required by S2 Authenication
 
 ## Dependencies
 

--- a/ansible/roles/zwavejs/README.md
+++ b/ansible/roles/zwavejs/README.md
@@ -17,13 +17,32 @@ Timezone code for the container.
 
 Zwave serial device to attach to the Docker container
 
-
     zwavejs_keys_s2_unauthenticated
     zwavejs_keys_s2_authenticated
     zwavejs_keys_s2_accesscontrol
     zwavejs_keys_s0_legacy
 
 The various security keys required by S2 Authenication
+
+    zwavejs_container_name: "zwave-js-ui"
+
+Name of the Docker container.
+
+    zwavejs_docker_image_name: "zwavejs/zwave-js-ui"
+
+Base name of the Docker image to use for the container.
+
+    zwavejsui_docker_image_version: "latest"
+
+Specific Docker image version to use for the container.
+
+    zwavejs_docker_use_volumes
+
+Create and use Docker volumes for storing data. True when you want to use volumes.
+
+    zwavejs_conf_dir
+
+ Directory on filesystem to use for storing data files. Used when zwavejs_docker_use_volumes is false.
 
 ## Dependencies
 
@@ -32,8 +51,8 @@ None
 ## Example Playbook
 
     - hosts: all
-    roles:
-        - role: jellyfin
+        roles:
+            - role: zwavejs
 
 ## License
 

--- a/ansible/roles/zwavejs/README.md
+++ b/ansible/roles/zwavejs/README.md
@@ -1,0 +1,32 @@
+# Zwave JS UI
+
+Configures ZwaveJS Docker
+
+## Requirements
+
+Ansible 2.10 or newer.
+Docker
+
+## Role Variables
+
+  ansible_nas_timezone
+
+Timezone code for the container.
+
+  zwavejs_device
+
+Zwave serial device to attach to the Docker container
+
+## Dependencies
+
+None
+
+## Example Playbook
+
+    - hosts: all
+    roles:
+        - role: jellyfin
+
+## License
+
+MIT

--- a/ansible/roles/zwavejs/README.md
+++ b/ansible/roles/zwavejs/README.md
@@ -44,6 +44,10 @@ Create and use Docker volumes for storing data. True when you want to use volume
 
  Directory on filesystem to use for storing data files. Used when zwavejs_docker_use_volumes is false.
 
+    homeassistant_host
+
+Homeassistant Instance Hostname or IP address
+
 ## Dependencies
 
 None

--- a/ansible/roles/zwavejs/defaults/main.yml
+++ b/ansible/roles/zwavejs/defaults/main.yml
@@ -1,0 +1,17 @@
+---
+
+# Volumes or data dir?
+zwavejsui_docker_use_volumes: true
+zwavejs_docker_data_dir: "/var/lib/zwavejsui"
+
+zwavejs_container_name: zwavejs
+
+zwavejs_docker_image_name: zwavejs/zwave-js-ui
+zwavejs_docker_image_version: latest
+
+zwavejs_root_dir: "/docker/{{ zwavejs_container_name }}"
+zwavejs_conf_dir: "{{ zwavejs_root_dir }}"
+
+# Do not use /dev/ttyUSBX serial devices, as those mappings can change over time.
+# Instead, use the /dev/serial/by-id/X serial device for your Z-Wave stick.
+zwavejs_docker_device: ""

--- a/ansible/roles/zwavejs/handlers/main.yml
+++ b/ansible/roles/zwavejs/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for zwavejs

--- a/ansible/roles/zwavejs/meta/main.yml
+++ b/ansible/roles/zwavejs/meta/main.yml
@@ -1,13 +1,13 @@
+---
 galaxy_info:
   author: rikdc
   description: Configures and runs the zwavejs-ui docker container
   license: MIT
   min_ansible_version: "2.1"
-  platform:
-    - name: "Ubuntu"
+  platforms:
+    - name: Ubuntu
       versions:
-        - "bionic"
-        - "focal"
-        - "jammy"
+        - focal
+        - jammy
   galaxy_tags: []
 dependencies: []

--- a/ansible/roles/zwavejs/meta/main.yml
+++ b/ansible/roles/zwavejs/meta/main.yml
@@ -1,0 +1,13 @@
+galaxy_info:
+  author: rikdc
+  description: Configures and runs the zwavejs-ui docker container
+  license: MIT
+  min_ansible_version: "2.1"
+  platform:
+    - name: "Ubuntu"
+      versions:
+        - "bionic"
+        - "focal"
+        - "jammy"
+  galaxy_tags: []
+dependencies: []

--- a/ansible/roles/zwavejs/tasks/main.yml
+++ b/ansible/roles/zwavejs/tasks/main.yml
@@ -70,3 +70,9 @@
     labels:
       "com.centurylinklabs.watchtower.enable": "true"
   register: status
+  # vars:
+  #   ansible_python_interpreter: "/usr/bin/env python3-docker"
+
+# - assert:
+#     that:
+#       - "status.services.zwave.zwavejs_zwavejs2mqtt_1.state.running"

--- a/ansible/roles/zwavejs/tasks/main.yml
+++ b/ansible/roles/zwavejs/tasks/main.yml
@@ -59,18 +59,16 @@
       TZ: "{{ ansible_nas_timezone }}"
     stop_signal: SIGINT
     restart_policy: unless-stopped
-    # devices:
-    #   - "{{ zwavejs_docker_device }}:/dev/ttyACM0"
-    # volumes:
-    #   - zwave-config:/usr/src/app/store
+    devices:
+      - "{{ zwavejs_docker_device }}:/dev/ttyACM0"
+    volumes:
+      - zwave-config:/usr/src/app/store
     ports:
       - '8091:8091' # port for web interface
       - '3000:3000' # port for Z-Wave JS websocket server
     labels:
       "com.centurylinklabs.watchtower.enable": "true"
   register: status
-  # vars:
-  #   ansible_python_interpreter: "/usr/bin/env python3-docker"
 
 # - assert:
 #     that:

--- a/ansible/roles/zwavejs/tasks/main.yml
+++ b/ansible/roles/zwavejs/tasks/main.yml
@@ -14,7 +14,7 @@
   loop:
     - "minicom"
     - "lrzsz"
-  become: yes
+  become: true
   # https://github.com/kpine/zwave-js-server-docker/wiki/700-series-Controller-Firmware-Updates-(Linux)
 
 - name: Configuration | Ensure the container user group exists

--- a/ansible/roles/zwavejs/tasks/main.yml
+++ b/ansible/roles/zwavejs/tasks/main.yml
@@ -45,7 +45,6 @@
 
 - name: Configuration | Create configuration file from template
   become: true
-  #notify: restart influxdb
   ansible.builtin.template:
     mode: u=rw,g=r,o=r
     src: "settings.json.j2"

--- a/ansible/roles/zwavejs/tasks/main.yml
+++ b/ansible/roles/zwavejs/tasks/main.yml
@@ -5,7 +5,7 @@
       - source: "{{ zwavejs_docker_data_dir }}"
         target: "/usr/src/app/store"
         type: "bind"
-  when: "not zwavejsui_docker_use_volumes"
+  when: "not zwavejs_docker_use_volumes"
 
 - name: "Setup | Install prereqs to update controller"
   ansible.builtin.apt:

--- a/ansible/roles/zwavejs/tasks/main.yml
+++ b/ansible/roles/zwavejs/tasks/main.yml
@@ -1,0 +1,72 @@
+---
+- name: "Setup | Set Docker volume list for bind mounts"
+  ansible.builtin.set_fact:
+    _zwavejsui_docker_mount_list:
+      - source: "{{ zwavejs_docker_data_dir }}"
+        target: "/usr/src/app/store"
+        type: "bind"
+  when: "not zwavejsui_docker_use_volumes"
+
+- name: "Setup | Install prereqs to update controller"
+  ansible.builtin.apt:
+    name: "{{ item }}"
+    state: "latest"
+  loop:
+    - "minicom"
+    - "lrzsz"
+  become: yes
+  # https://github.com/kpine/zwave-js-server-docker/wiki/700-series-Controller-Firmware-Updates-(Linux)
+
+- name: Configuration | Ensure the container user group exists
+  ansible.builtin.group:
+    name: "zwavejsui"
+    state: present
+    system: true
+
+- name: Configuration | Ensure the container user exists
+  ansible.builtin.user:
+    name: "zwavejsui"
+    state: present
+    group: "zwavejsui"
+    create_home: false
+    system: true
+    shell: "/usr/sbin/nologin"
+
+- name: Configuration | create docker directory
+  become: true
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    mode: "{{ item.mode }}"
+    state: directory
+    owner: "zwavejsui"
+    group: "zwavejsui"
+  loop:
+    - { path: "{{ zwavejs_conf_dir }}", mode: "0777" }
+
+- name: Configuration | Create configuration file from template
+  become: true
+  #notify: restart influxdb
+  ansible.builtin.template:
+    mode: u=rw,g=r,o=r
+    src: "settings.json.j2"
+    dest: "{{ zwavejs_conf_dir }}/settings.json"
+
+- name: Container | Start or restart ZwavejsUI container
+  become: true
+  community.docker.docker_container:
+    name: "{{ zwavejs_container_name }}"
+    image: "{{ zwavejs_docker_image_name }}:{{ zwavejs_docker_image_version }}"
+    env:
+      TZ: "{{ ansible_nas_timezone }}"
+    stop_signal: SIGINT
+    restart_policy: unless-stopped
+    # devices:
+    #   - "{{ zwavejs_docker_device }}:/dev/ttyACM0"
+    # volumes:
+    #   - zwave-config:/usr/src/app/store
+    ports:
+      - '8091:8091' # port for web interface
+      - '3000:3000' # port for Z-Wave JS websocket server
+    labels:
+      "com.centurylinklabs.watchtower.enable": "true"
+  register: status

--- a/ansible/roles/zwavejs/templates/settings.json.j2
+++ b/ansible/roles/zwavejs/templates/settings.json.j2
@@ -1,7 +1,7 @@
 {
   "mqtt": {
     "name": "homeassistant",
-    "host": "192.168.10.8",
+    "host": "{{ homeassistant_host }}",
     "port": 1883,
     "qos": 0,
     "prefix": "homeassistant",

--- a/ansible/roles/zwavejs/templates/settings.json.j2
+++ b/ansible/roles/zwavejs/templates/settings.json.j2
@@ -1,0 +1,73 @@
+{
+  "mqtt": {
+    "name": "homeassistant",
+    "host": "192.168.10.8",
+    "port": 1883,
+    "qos": 0,
+    "prefix": "homeassistant",
+    "reconnectPeriod": 5000,
+    "retain": true,
+    "clean": true,
+    "auth": false,
+    "_ca": "",
+    "ca": "",
+    "_cert": "",
+    "cert": "",
+    "_key": "",
+    "key": "",
+    "store": true,
+    "disabled": true
+  },
+  "gateway": {
+    "type": 0,
+    "plugins": [
+      "@varet/zj2m-prom-exporter"
+    ],
+    "authEnabled": false,
+    "payloadType": 1,
+    "nodeNames": true,
+    "hassDiscovery": false,
+    "discoveryPrefix": "homeassistant",
+    "logEnabled": false,
+    "logLevel": "debug",
+    "logToFile": false,
+    "values": [],
+    "retainedDiscovery": true,
+    "includeNodeInfo": true,
+    "publishNodeDetails": true,
+    "sendEvents": true
+  },
+  "zwave": {
+    "port": "/dev     /ttyACM0",
+    "commandsTimeout": 15000,
+    "logLevel": "debug",
+    "logEnabled": true,
+    "securityKeys": {
+      "S0_Legacy": "{{ zwavejs_keys_s0_legacy }}",
+      "S2_Unauthenticated": "{{ zwavejs_keys_s2_unauthenticated }}",
+      "S2_AccessControl": "{{ zwavejs_keys_s2_accesscontrol }}",
+      "S2_Authenticated": "{{ zwavejs_keys_s2_authenticated }}"
+    },
+    "deviceConfigPriorityDir": "/usr/src/app/store/config",
+    "logToFile": false,
+    "serverEnabled": true,
+    "serverServiceDiscoveryDisabled": false,
+    "enableSoftReset": true,
+    "enableStatistics": true,
+    "serverPort": 3000,
+    "maxNodeEventsQueueSize": 100,
+    "logging": true,
+    "saveConfig": true,
+    "pollInterval": 5000,
+    "disclaimerVersion": 1
+  },
+  "backup": {
+    "storeBackup": false,
+    "storeCron": "0 0 * * *",
+    "storeKeep": 7,
+    "nvmBackup": false,
+    "nvmBackupOnEvent": false,
+    "nvmCron": "0 0 * * *",
+    "nvmKeep": 7
+  }
+}

--- a/ansible/roles/zwavejs/tests/inventory
+++ b/ansible/roles/zwavejs/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/ansible/roles/zwavejs/tests/test.yml
+++ b/ansible/roles/zwavejs/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - zwavejs

--- a/ansible/roles/zwavejs/vars/main.yml
+++ b/ansible/roles/zwavejs/vars/main.yml
@@ -1,2 +1,3 @@
 ---
 # vars file for zwavejs
+homeassistant_host: homeassistant

--- a/ansible/roles/zwavejs/vars/main.yml
+++ b/ansible/roles/zwavejs/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for zwavejs


### PR DESCRIPTION
Create a container for ZwaveJS. This container should be configurable, allowing the homeassistant url and mqtt settings be set within the ansible role vars.