### PR TITLE
fix: update secretStoreRef name to vault-k8s-auth

### DIFF
--- a/k3s/apps/openwebui/values.yaml
+++ b/k3s/apps/openwebui/values.yaml
@@ -25,7 +25,7 @@ externalSecret:
   namespace: tools
   refreshInterval: "15s"
   secretStoreRef:
-    name: vault-backend
+    name: vault-k8s-auth
     kind: ClusterSecretStore
   target:
     name: openwebui-secrets


### PR DESCRIPTION
fix: update secretStoreRef name to vault-k8s-auth in externalSecret configuration