### PR TITLE
chore: update open-webui version to 6.19.0 in Chart.yaml

### DIFF
--- a/k3s/apps/openwebui/Chart.yaml
+++ b/k3s/apps/openwebui/Chart.yaml
@@ -1,8 +1,8 @@
 ---
 apiVersion: v2
 name: open-webui
-version: 5.24.0
+version: 6.19.0
 dependencies:
   - name: open-webui
-    version: 5.24.0
+    version: 6.19.0
     repository: https://helm.openwebui.com/


### PR DESCRIPTION
This pull request updates the `open-webui` Helm chart to a newer version. The most important change is the version bump from `5.24.0` to `6.19.0` in the `Chart.yaml` file.

Version update:

* [`k3s/apps/openwebui/Chart.yaml`](diffhunk://#diff-26bdd6fa1a3837422c2d21f6ae78b9d80dfe410fe23dbe253af069ae683631d5L4-R7): Updated the chart version and dependency version from `5.24.0` to `6.19.0` to reflect the latest release.