### PR TITLE
Add n8n helm chart module

### DIFF
--- a/k3s/apps/n8n/Chart.yaml
+++ b/k3s/apps/n8n/Chart.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v2
+name: n8n
+version: 0.22.0
+dependencies:
+  - name: n8n
+    version: 0.22.0
+    repository: https://8gears.github.io/n8n-helm-chart/

--- a/k3s/apps/n8n/README.md
+++ b/k3s/apps/n8n/README.md
@@ -1,0 +1,50 @@
+# n8n Helm Deployment
+
+This directory contains configuration for deploying [n8n](https://n8n.io), an open-source workflow automation tool, using Helm.
+
+## Prerequisites
+
+1. Deploy the NFS storage classes:
+   ```bash
+   kubectl apply -f ../../nfs-storage-class.yaml
+   ```
+2. Ensure required namespaces exist:
+   ```bash
+   kubectl apply -f ../../namespaces.yaml
+   ```
+3. Create the persistent volumes and claims:
+   ```bash
+   kubectl apply -f ../../persistent-volumes/tools/n8n.yaml
+   ```
+
+## Deployment
+
+Add the n8n Helm repository and install using the provided values file:
+
+```bash
+helm repo add n8n https://8gears.github.io/n8n-helm-chart/
+helm repo update
+helm install n8n n8n/n8n \
+  -f values.yaml \
+  -n tools
+```
+
+## Upgrading
+
+To upgrade the deployment:
+
+```bash
+helm upgrade n8n n8n/n8n \
+  -f values.yaml \
+  -n tools
+```
+
+## Configuration
+
+The `values.yaml` file contains configuration for storage, secrets and the n8n chart. Key settings include:
+
+- **Storage**: Creates a persistent volume and claim backed by NFS for n8n data
+- **External Secrets**: Retrieves credentials such as `DATABASE_URL` and authentication details from Vault
+- **Ingress**: Exposes n8n at `n8n.home.lan`
+
+Adjust the values as needed for your environment.

--- a/k3s/apps/n8n/templates/priorityclass.yaml
+++ b/k3s/apps/n8n/templates/priorityclass.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: low-priority
+value: 100
+globalDefault: false
+description: "Lower priority class for n8n pods."

--- a/k3s/apps/n8n/templates/secrets.yaml
+++ b/k3s/apps/n8n/templates/secrets.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.externalSecret.name | default "n8n-external-secret" }}
+  namespace: {{ .Values.externalSecret.namespace | default "tools" }}
+spec:
+  refreshInterval: {{ .Values.externalSecret.refreshInterval | default "15s" }}
+  secretStoreRef:
+    name: {{ .Values.externalSecret.secretStoreRef.name | default "vault-k8s-auth" }}
+    kind: {{ .Values.externalSecret.secretStoreRef.kind | default "ClusterSecretStore" }}
+  target:
+    name: {{ .Values.externalSecret.target.name | default "n8n-secrets" }}
+  data:
+{{- range .Values.externalSecret.data }}
+    - secretKey: {{ .secretKey }}
+      remoteRef:
+        key: {{ .remoteRef.key }}
+        property: {{ .remoteRef.property }}
+{{- end }}

--- a/k3s/apps/n8n/templates/storage.yaml
+++ b/k3s/apps/n8n/templates/storage.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ .Values.storage.pv.name }}
+  labels:
+    type: {{ .Values.storage.pv.labels.type }}
+    app: {{ .Values.storage.pv.labels.app }}
+spec:
+  capacity:
+    storage: {{ .Values.storage.pv.capacity }}
+  accessModes:
+    - {{ .Values.storage.pv.accessModes }}
+  persistentVolumeReclaimPolicy: {{ .Values.storage.pv.reclaimPolicy }}
+  storageClassName: {{ .Values.storage.pv.storageClassName }}
+  nfs:
+    server: {{ .Values.storage.pv.nfs.server }}
+    path: {{ .Values.storage.pv.nfs.path }}
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.storage.pvc.name }}
+  namespace: {{ .Values.storage.pvc.namespace }}
+spec:
+  accessModes:
+    - {{ .Values.storage.pvc.accessModes }}
+  resources:
+    requests:
+      storage: {{ .Values.storage.pvc.requests.storage }}
+  storageClassName: {{ .Values.storage.pvc.storageClassName }}

--- a/k3s/apps/n8n/values.yaml
+++ b/k3s/apps/n8n/values.yaml
@@ -1,0 +1,90 @@
+---
+storage:
+  pv:
+    name: n8n-data-pv
+    labels:
+      type: data
+      app: n8n
+    capacity: 1Gi
+    accessModes: ReadWriteMany
+    reclaimPolicy: Retain
+    storageClassName: nfs-storage
+    nfs:
+      server: 192.168.88.211
+      path: /volume1/docker/n8n
+  pvc:
+    name: n8n-data-pvc
+    namespace: tools
+    accessModes: ReadWriteMany
+    requests:
+      storage: 1Gi
+    storageClassName: nfs-storage
+
+externalSecret:
+  name: n8n-external-secret
+  namespace: tools
+  refreshInterval: "15s"
+  secretStoreRef:
+    name: vault-k8s-auth
+    kind: ClusterSecretStore
+  target:
+    name: n8n-secrets
+  data:
+    - secretKey: N8N_ENCRYPTION_KEY
+      remoteRef:
+        key: secrets/n8n
+        property: N8N_ENCRYPTION_KEY
+    - secretKey: DATABASE_URL
+      remoteRef:
+        key: secrets/n8n
+        property: DATABASE_URL
+    - secretKey: N8N_BASIC_AUTH_USER
+      remoteRef:
+        key: secrets/n8n
+        property: N8N_BASIC_AUTH_USER
+    - secretKey: N8N_BASIC_AUTH_PASSWORD
+      remoteRef:
+        key: secrets/n8n
+        property: N8N_BASIC_AUTH_PASSWORD
+
+n8n:
+  namespaceOverride: tools
+  persistence:
+    existingClaim: "n8n-data-pvc"
+    storageClass: "nfs-storage"
+  extraEnv:
+    - name: N8N_ENCRYPTION_KEY
+      valueFrom:
+        secretKeyRef:
+          name: n8n-secrets
+          key: N8N_ENCRYPTION_KEY
+    - name: DATABASE_URL
+      valueFrom:
+        secretKeyRef:
+          name: n8n-secrets
+          key: DATABASE_URL
+    - name: N8N_BASIC_AUTH_USER
+      valueFrom:
+        secretKeyRef:
+          name: n8n-secrets
+          key: N8N_BASIC_AUTH_USER
+    - name: N8N_BASIC_AUTH_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: n8n-secrets
+          key: N8N_BASIC_AUTH_PASSWORD
+  resources:
+    requests:
+      cpu: "250m"
+      memory: "256Mi"
+    limits:
+      cpu: "500m"
+      memory: "512Mi"
+  ingress:
+    enabled: true
+    annotations: {}
+    host: n8n.home.lan
+  service:
+    type: NodePort
+    port: 5678
+  priorityClassName: low-priority


### PR DESCRIPTION
## Summary
- add helm chart for `n8n` using the community maintained chart from 8gears
- define storage, secrets and ingress values
- include templates for storage, priority class and ExternalSecret
- document installation and usage in README

## Testing
- `make lint`

------
https://chatgpt.com/codex/tasks/task_e_6861aaf8834c8322a55fdd3cd88f82bc