### PR TITLE
Add permissions to README workflow

### DIFF
--- a/.github/workflows/readme.yml
+++ b/.github/workflows/readme.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   generate-readme:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary
- allow GitHub Actions write access for README updates

## Testing
- `make lint-yaml`
- `make lint-ansible` *(fails: ansible-lint not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861bd404c3083228d6222545f20e727