### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,7 @@
 ---
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/rikdc/home-network-config/security/code-scanning/3](https://github.com/rikdc/home-network-config/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow primarily involves linting and does not require write access, we will set the permissions to `contents: read`. This ensures the workflow adheres to the principle of least privilege while maintaining its functionality.

The `permissions` block will be added at the root level of the workflow, applying to all jobs. This approach is simpler and avoids redundancy, as all jobs in the workflow share the same minimal permission requirements.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
