### PR TITLE
Refine docmost chart

### DIFF
--- a/k3s/apps/docmost/Chart.yaml
+++ b/k3s/apps/docmost/Chart.yaml
@@ -6,4 +6,9 @@ description: A Helm chart for deploying Docmost, an open-source collaborative wi
 type: application
 maintainers:
   - name: Home Network Admin
-appVersion: "latest"
+    email: git@claydon.co
+home: https://github.com/docmost/docmost
+sources:
+  - https://github.com/docmost/docmost
+icon: https://raw.githubusercontent.com/docmost/docmost/main/apps/client/public/vite.svg
+appVersion: "0.21.0"

--- a/k3s/apps/docmost/README.md
+++ b/k3s/apps/docmost/README.md
@@ -33,14 +33,17 @@ The following table lists the configurable parameters of the Docmost chart and t
 | `replicaCount` | Number of Docmost replicas | `1` |
 | `nameOverride` | Override the name of the chart | `""` |
 | `fullnameOverride` | Override the full name of the chart | `""` |
+| `serviceAccount.create` | Create service account | `true` |
+| `serviceAccount.name` | Service account name | `""` |
 
 ### Image Configuration
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `image.repository` | Docmost image repository | `docmost/docmost` |
-| `image.tag` | Docmost image tag | `latest` |
+| `image.tag` | Docmost image tag | `0.21.0` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
+| `imagePullSecrets` | Image pull secrets | `[]` |
 
 ### Service Configuration
 
@@ -69,20 +72,32 @@ The following table lists the configurable parameters of the Docmost chart and t
 | `resources.requests.cpu` | CPU request | `500m` |
 | `resources.requests.memory` | Memory request | `500Mi` |
 
+### Scheduling and Security
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `nodeSelector` | Node selection constraints | `{}` |
+| `tolerations` | Tolerations for taints | `[]` |
+| `affinity` | Pod affinity rules | `{}` |
+| `securityContext` | Container security context | See values.yaml |
+
 ### Persistence Configuration
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `persistence.enabled` | Enable persistence | `true` |
-| `persistence.existingClaim` | Use existing PVC | `docmost-data-pv-pvc` |
+| `persistence.createPV` | Create a persistent volume | `false` |
 | `persistence.size` | Storage size | `10Gi` |
-| `persistence.storageClass` | Storage class | `nfs-client` |
+| `persistence.storageClass` | Storage class | `nfs-storage` |
 
 ### Redis Configuration
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `redis.enabled` | Enable Redis sidecar | `true` |
+| `redis.enabled` | Enable Redis | `true` |
+| `redis.sidecar` | Deploy Redis as sidecar | `true` |
+| `redis.externalHost` | External Redis host | `""` |
+| `redis.externalPort` | External Redis port | `6379` |
 | `redis.image.repository` | Redis image repository | `redis` |
 | `redis.image.tag` | Redis image tag | `7-alpine` |
 | `redis.resources` | Redis resource requirements | See values.yaml |

--- a/k3s/apps/docmost/templates/_helpers.tpl
+++ b/k3s/apps/docmost/templates/_helpers.tpl
@@ -49,3 +49,14 @@ Selector labels
 app.kubernetes.io/name: {{ include "docmost.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Return the name of the service account to use
+*/}}
+{{- define "docmost.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "docmost.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end }}

--- a/k3s/apps/docmost/templates/deployment.yaml
+++ b/k3s/apps/docmost/templates/deployment.yaml
@@ -3,7 +3,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "docmost.fullname" . }}
-  namespace: {{ .Values.namespace }}
   labels:
     {{- include "docmost.labels" . | nindent 4 }}
 spec:
@@ -16,10 +15,17 @@ spec:
       labels:
         {{- include "docmost.selectorLabels" . | nindent 8 }}
     spec:
+      serviceAccountName: {{ include "docmost.serviceAccountName" . }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           ports:
             - name: http
               containerPort: {{ .Values.service.targetPort }}
@@ -58,7 +64,7 @@ spec:
             initialDelaySeconds: 5
             timeoutSeconds: 3
             periodSeconds: 5
-        {{- if .Values.redis.enabled }}
+        {{- if and .Values.redis.enabled .Values.redis.sidecar }}
         - name: redis
           image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
           ports:
@@ -67,6 +73,8 @@ spec:
               protocol: TCP
           resources:
             {{- toYaml .Values.redis.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           volumeMounts:
             - name: redis-data
               mountPath: /data
@@ -85,7 +93,13 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: {{ .Values.persistence.pvcName }}
-        {{- if .Values.redis.enabled }}
+        {{- if and .Values.redis.enabled .Values.redis.sidecar }}
         - name: redis-data
           emptyDir: {}
         {{- end }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}
+      affinity:
+        {{- toYaml .Values.affinity | nindent 8 }}

--- a/k3s/apps/docmost/templates/external-secret.yaml
+++ b/k3s/apps/docmost/templates/external-secret.yaml
@@ -1,10 +1,9 @@
+{{- if .Values.externalSecrets.enabled }}
 ---
-{{- if .Values.externalSecrets.enabled -}}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: {{ include "docmost.fullname" . }}-external-secret
-  namespace: {{ .Values.namespace }}
   labels:
     {{- include "docmost.labels" . | nindent 4 }}
 spec:

--- a/k3s/apps/docmost/templates/ingress.yaml
+++ b/k3s/apps/docmost/templates/ingress.yaml
@@ -1,10 +1,9 @@
+{{- if .Values.ingress.enabled }}
 ---
-{{- if .Values.ingress.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "docmost.fullname" . }}
-  namespace: {{ .Values.namespace }}
   labels:
     {{- include "docmost.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}

--- a/k3s/apps/docmost/templates/persistent-volume-claim.yaml
+++ b/k3s/apps/docmost/templates/persistent-volume-claim.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ .Values.persistence.pvcName }}
-  namespace: {{ .Values.namespace }}
   labels:
     {{- include "docmost.labels" . | nindent 4 }}
 spec:
@@ -13,5 +12,7 @@ spec:
     requests:
       storage: {{ .Values.persistence.size }}
   storageClassName: {{ .Values.persistence.storageClass }}
+  {{- if .Values.persistence.createPV }}
   volumeName: {{ .Values.persistence.pvName }}
+  {{- end }}
 {{- end }}

--- a/k3s/apps/docmost/templates/persistent-volume.yaml
+++ b/k3s/apps/docmost/templates/persistent-volume.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.persistence.enabled }}
+{{- if and .Values.persistence.enabled .Values.persistence.createPV }}
 apiVersion: v1
 kind: PersistentVolume
 metadata:

--- a/k3s/apps/docmost/templates/service-account.yaml
+++ b/k3s/apps/docmost/templates/service-account.yaml
@@ -1,6 +1,6 @@
----
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.serviceAccount.name }}
-  namespace: {{ .Values.serviceAccount.namespace }}
+  name: {{ include "docmost.serviceAccountName" . }}
+{{- end }}

--- a/k3s/apps/docmost/templates/service.yaml
+++ b/k3s/apps/docmost/templates/service.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "docmost.fullname" . }}
-  namespace: {{ .Values.namespace }}
   labels:
     {{- include "docmost.labels" . | nindent 4 }}
 spec:

--- a/k3s/apps/docmost/values.yaml
+++ b/k3s/apps/docmost/values.yaml
@@ -5,16 +5,18 @@ replicaCount: 1
 
 image:
   repository: docmost/docmost
-  tag: latest
+  tag: "0.21.0"
   pullPolicy: IfNotPresent
+
+# optionally specify image pull secrets
+imagePullSecrets: []
 
 nameOverride: ""
 fullnameOverride: ""
-namespace: tools
 
 serviceAccount:
-  name: eso-vault-auth
-  namespace: tools
+  create: true
+  name: ""
 
 service:
   type: ClusterIP
@@ -46,6 +48,7 @@ resources:
 
 persistence:
   enabled: true
+  createPV: false
   size: 10Gi
   storageClass: nfs-storage
   pvName: docmost-data-pv
@@ -56,6 +59,9 @@ persistence:
 
 redis:
   enabled: true
+  sidecar: true
+  externalHost: ""
+  externalPort: 6379
   image:
     repository: redis
     tag: 7-alpine
@@ -93,3 +99,15 @@ env:
     value: "America/New_York"
   - name: REDIS_URL
     value: "redis://localhost:6379"
+
+# Pod scheduling options
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# Container security context
+securityContext:
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  runAsNonRoot: true


### PR DESCRIPTION
## Summary
- pin Docmost image to 0.21.0 and extend chart metadata
- remove hard-coded namespaces and add service account helper
- allow optional PV creation and Redis sidecar
- expose scheduling and security settings in values
- document configuration updates in README
- fix lint errors in templated manifests

## Testing
- `pre-commit run --files k3s/apps/docmost/...` ✔
- `helm lint k3s/apps/docmost` ✔

------
https://chatgpt.com/codex/tasks/task_e_68666477ea9c83229b4f685cbddea558