### PR TITLE
feat(vault): Vault PKI backend setup via Ansible

### DIFF
--- a/ansible/inventory/group_vars/vault_pki.yml
+++ b/ansible/inventory/group_vars/vault_pki.yml
@@ -1,0 +1,46 @@
+---
+# Vault PKI Configuration Variables
+# These variables can be overridden at runtime or in host-specific files
+
+# Vault server configuration
+vault_server_url: "https://vault.home.lan:8200"
+
+# Kubernetes cluster configuration
+k8s_api_server: "https://192.168.88.59:6443"
+
+# SSL certificate domain configuration
+ssl_domain: "claydon.co"
+ssl_subdomain: "home.claydon.co"
+
+# Certificate validity periods
+certificate_ttl: "8760h"    # 1 year for leaf certificates
+ca_certificate_ttl: "87600h"   # 10 years for root CA
+
+# PKI role name (derived from subdomain)
+pki_role_name: "home-claydon-co"
+
+# External Secrets configuration
+external_secrets_namespace: "external-secrets"
+external_secrets_service_account: "external-secrets"
+
+# DNS entries that will be created for SSL endpoints
+ssl_endpoints:
+  - "chat.{{ ssl_subdomain }}"     # OpenWebUI
+  - "docs.{{ ssl_subdomain }}"     # Docmost
+  - "n8n.{{ ssl_subdomain }}"      # n8n
+  - "ca.{{ ssl_subdomain }}"       # CA download site
+  - "vault.{{ ssl_subdomain }}"    # Vault UI (if exposed)
+
+# Usage examples:
+#
+# Run playbook with default values:
+#   ansible-playbook playbooks/vault-pki-setup.yml
+#
+# Override domain at runtime:
+#   ansible-playbook playbooks/vault-pki-setup.yml -e ssl_domain=example.com -e ssl_subdomain=home.example.com
+#
+# Override Vault server URL:
+#   ansible-playbook playbooks/vault-pki-setup.yml -e vault_server_url=https://vault.example.com:8200
+#
+# Override Kubernetes API server:
+#   ansible-playbook playbooks/vault-pki-setup.yml -e k8s_api_server=https://10.0.0.100:6443

--- a/ansible/playbooks/vault-pki-setup.yml
+++ b/ansible/playbooks/vault-pki-setup.yml
@@ -1,0 +1,228 @@
+---
+- name: Configure Vault PKI for SSL Certificate Management
+  hosts: vault
+  vars_files:
+    - ../default.config.yml
+    - ../secrets.enc
+  vars:
+    # Configurable variables - override in inventory or command line
+    vault_addr: "{{ vault_server_url | default('https://vault.home.lan:8200') }}"
+    kubernetes_api_server: "{{ k8s_api_server | default('https://192.168.88.59:6443') }}"
+    pki_domain: "{{ ssl_domain | default('claydon.co') }}"
+    pki_subdomain: "{{ ssl_subdomain | default('home.claydon.co') }}"
+    cert_ttl: "{{ certificate_ttl | default('8760h') }}"  # 1 year
+    ca_ttl: "{{ ca_certificate_ttl | default('87600h') }}"   # 10 years
+    
+  tasks:
+    - name: Wait for Vault to be ready
+      uri:
+        url: "{{ vault_addr }}/v1/sys/health"
+        method: GET
+        validate_certs: false
+        status_code: [200, 429, 472, 473, 503]
+      register: vault_health
+      until: vault_health.status in [200, 429]
+      retries: 30
+      delay: 5
+
+    - name: Check if Vault is initialized
+      uri:
+        url: "{{ vault_addr }}/v1/sys/init"
+        method: GET
+        validate_certs: false
+      register: vault_init_status
+
+    - name: Fail if Vault is not initialized
+      fail:
+        msg: "Vault is not initialized. Please initialize Vault first."
+      when: not vault_init_status.json.initialized
+
+    - name: Check if PKI secrets engine exists
+      uri:
+        url: "{{ vault_addr }}/v1/sys/mounts/pki_homelab"
+        method: GET
+        validate_certs: false
+        headers:
+          X-Vault-Token: "{{ vault_root_token }}"
+        status_code: [200, 404]
+      register: pki_mount_check
+
+    - name: Enable PKI secrets engine
+      uri:
+        url: "{{ vault_addr }}/v1/sys/mounts/pki_homelab"
+        method: POST
+        validate_certs: false
+        headers:
+          X-Vault-Token: "{{ vault_root_token }}"
+        body_format: json
+        body:
+          type: "pki"
+          description: "HomeL PKI for {{ pki_domain }}"
+          config:
+            max_lease_ttl: "{{ ca_ttl }}"
+      when: pki_mount_check.status == 404
+
+    - name: Configure PKI URLs
+      uri:
+        url: "{{ vault_addr }}/v1/pki_homelab/config/urls"
+        method: POST
+        validate_certs: false
+        headers:
+          X-Vault-Token: "{{ vault_root_token }}"
+        body_format: json
+        body:
+          issuing_certificates: ["{{ vault_addr }}/v1/pki_homelab/ca"]
+          crl_distribution_points: ["{{ vault_addr }}/v1/pki_homelab/crl"]
+
+    - name: Check if root CA exists
+      uri:
+        url: "{{ vault_addr }}/v1/pki_homelab/cert/ca"
+        method: GET
+        validate_certs: false
+        headers:
+          X-Vault-Token: "{{ vault_root_token }}"
+        status_code: [200, 404]
+      register: root_ca_check
+
+    - name: Generate root CA certificate
+      uri:
+        url: "{{ vault_addr }}/v1/pki_homelab/root/generate/internal"
+        method: POST
+        validate_certs: false
+        headers:
+          X-Vault-Token: "{{ vault_root_token }}"
+        body_format: json
+        body:
+          common_name: "Home Lab Root CA"
+          ttl: "{{ ca_ttl }}"
+          key_type: "rsa"
+          key_bits: 4096
+          country: "US"
+          organization: "Home Lab"
+          ou: "Home Lab Root CA"
+      register: root_ca_result
+      when: root_ca_check.status == 404
+
+    - name: Create PKI role for {{ pki_subdomain }}
+      uri:
+        url: "{{ vault_addr }}/v1/pki_homelab/roles/{{ pki_subdomain | replace('.', '-') }}"
+        method: POST
+        validate_certs: false
+        headers:
+          X-Vault-Token: "{{ vault_root_token }}"
+        body_format: json
+        body:
+          allowed_domains: "{{ pki_subdomain }}"
+          allow_subdomains: true
+          allow_glob_domains: true
+          allow_wildcard_certificates: true
+          max_ttl: "{{ cert_ttl }}"
+          key_type: "ec"
+          key_bits: 256
+
+    - name: Enable Kubernetes auth method
+      uri:
+        url: "{{ vault_addr }}/v1/sys/auth/kubernetes"
+        method: POST
+        validate_certs: false
+        headers:
+          X-Vault-Token: "{{ vault_root_token }}"
+        body_format: json
+        body:
+          type: "kubernetes"
+        status_code: [200, 400]  # 400 if already exists
+
+    - name: Configure Kubernetes auth method
+      uri:
+        url: "{{ vault_addr }}/v1/auth/kubernetes/config"
+        method: POST
+        validate_certs: false
+        headers:
+          X-Vault-Token: "{{ vault_root_token }}"
+        body_format: json
+        body:
+          kubernetes_host: "{{ kubernetes_api_server }}"
+          kubernetes_ca_cert: "{{ lookup('file', '../k8s-ca.crt') }}"
+
+    - name: Create policy for External Secrets Operator
+      uri:
+        url: "{{ vault_addr }}/v1/sys/policies/acl/eso-pki-policy"
+        method: PUT
+        validate_certs: false
+        headers:
+          X-Vault-Token: "{{ vault_root_token }}"
+        body_format: json
+        body:
+          policy: |
+            path "pki_homelab/issue/{{ pki_subdomain | replace('.', '-') }}" {
+              capabilities = ["create", "update"]
+            }
+            path "pki_homelab/cert/ca" {
+              capabilities = ["read"]
+            }
+
+    - name: Create Kubernetes auth role for External Secrets
+      uri:
+        url: "{{ vault_addr }}/v1/auth/kubernetes/role/eso"
+        method: POST
+        validate_certs: false
+        headers:
+          X-Vault-Token: "{{ vault_root_token }}"
+        body_format: json
+        body:
+          bound_service_account_names: ["external-secrets"]
+          bound_service_account_namespaces: ["{{ external_secrets_namespace | default('external-secrets') }}"]
+          policies: ["eso-pki-policy"]
+          ttl: "24h"
+
+    - name: Get root CA certificate for distribution
+      uri:
+        url: "{{ vault_addr }}/v1/pki_homelab/cert/ca"
+        method: GET
+        validate_certs: false
+        headers:
+          X-Vault-Token: "{{ vault_root_token }}"
+      register: vault_ca_cert
+
+    - name: Save root CA certificate locally
+      copy:
+        content: "{{ vault_ca_cert.json.data.certificate }}"
+        dest: "../vault-ca.pem"
+        mode: '0644'
+
+    - name: Create base64 encoded CA certificate for Kubernetes
+      shell: base64 -b 0 ../vault-ca.pem > ../vault-ca-b64.txt
+      args:
+        creates: ../vault-ca-b64.txt
+
+    - name: Read base64 CA certificate
+      slurp:
+        src: "../vault-ca-b64.txt"
+      register: vault_ca_b64_content
+
+    - name: Generate ClusterSecretStore from template
+      template:
+        src: "../../k3s/platform/ssl-certificates/templates/cluster-secret-store.yaml.j2"
+        dest: "../../k3s/platform/ssl-certificates/01-cluster-secret-store.yaml"
+        mode: '0644'
+      vars:
+        vault_ca_bundle_b64: "{{ vault_ca_b64_content.content | b64decode | trim }}"
+
+    - name: Display setup completion message
+      debug:
+        msg: |
+          Vault PKI setup completed successfully!
+          - Vault Server: {{ vault_addr }}
+          - Kubernetes API: {{ kubernetes_api_server }}
+          - Domain: {{ pki_domain }}
+          - Subdomain: {{ pki_subdomain }}
+          - Root CA created with {{ ca_ttl }} validity
+          - PKI role '{{ pki_subdomain | replace('.', '-') }}' configured for *.{{ pki_subdomain }}
+          - Kubernetes auth method configured
+          - External Secrets Operator policy and role created
+          - Root CA certificate saved to vault-ca.pem
+          
+          Next steps:
+          1. Deploy External Secrets configuration
+          2. Configure DNS for {{ pki_subdomain }}
+          3. Update application ingresses for SSL


### PR DESCRIPTION

## Summary

- Adds the necessary Ansible inventory and playbook to set up the Vault PKI backend for issuing internal SSL certificates. This is foundational for the new certificate management system.

## Test plan

- Execute the `vault-pki-setup.yml` playbook against the vault server.
- Verify that the CA is configured and the necessary roles are created in Vault.

💘 Generated with Crush