### PR TITLE
Updated pvc for Gitea

### DIFF
--- a/k3s/platform/gitea/values.yaml
+++ b/k3s/platform/gitea/values.yaml
@@ -89,4 +89,5 @@ gitea:
 
   persistence:
     enabled: true
-    existingClaim: gitea-data-pvc
+    create: false
+    claimName: gitea-data-pvc

--- a/k3s/platform/gitea/values.yaml
+++ b/k3s/platform/gitea/values.yaml
@@ -89,5 +89,4 @@ gitea:
 
   persistence:
     enabled: true
-    type: existingClaim
     existingClaim: gitea-data-pvc

--- a/k3s/platform/gitea/values.yaml
+++ b/k3s/platform/gitea/values.yaml
@@ -87,6 +87,7 @@ gitea:
 
   namespace: tools
 
-persistence:
-  enabled: true
-  existingClaim: gitea-data-pvc
+  persistence:
+    enabled: true
+    type: existingClaim
+    existingClaim: gitea-data-pvc

--- a/k3s/platform/gitea/values.yaml
+++ b/k3s/platform/gitea/values.yaml
@@ -85,8 +85,8 @@ gitea:
   redis:
     enabled: true
 
-  persistence:
-    enabled: true
-    existingClaim: gitea-data-pvc
-
   namespace: tools
+
+persistence:
+  enabled: true
+  existingClaim: gitea-data-pvc


### PR DESCRIPTION
## Summary
- ensure the Gitea subchart reuses the existing NAS-backed PVC
- disable PVC creation and set `claimName: gitea-data-pvc` so the StatefulSet mounts the right volume

## Testing
- helm template k3s/platform/gitea -n tools | rg 'claimName: gitea-data-pvc'
